### PR TITLE
[#51906587] Manage /var/log/wtmp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,4 +84,13 @@ class harden {
     source => 'puppet:///modules/harden/etc/ssh/ssh_config',
   }
 
+  # login(1), init(8) and getty(8) will not perform record-keeping, or
+  # attempt to recreate this file, if it doesn't exist.
+  file { '/var/log/wtmp':
+    ensure  => present,
+    owner   => 'root',
+    group   => 'utmp',
+    mode    => '0664',
+  }
+
 }


### PR DESCRIPTION
Ensure that `/var/log/wtmp` always exists and has the correct file
permissions. Don't manage it's contents.

If this file is deleted, as we've seen with some VM templates, then it won't
be recreated and logins will not be recorded. Subsequently last(1) will
complain as such:

```
~# last
last: /var/log/wtmp: No such file or directory
Perhaps this file was removed by the operator to prevent logging last info.
```

NB: This is complimentary to syslog's normal auth/authpriv log.
