### PR TITLE
[#65184950] Increase inotify max_user_instances

### DIFF
--- a/files/etc/sysctl.conf
+++ b/files/etc/sysctl.conf
@@ -12,3 +12,6 @@ net.ipv4.icmp_echo_ignore_broadcasts = 1
 net.ipv4.ip_forward = 0
 net.ipv4.tcp_max_syn_backlog = 4096
 net.ipv4.tcp_syncookies = 1
+
+# Increase max_user_instances of inotify instances from default of 128
+fs.inotify.max_user_instances=1024


### PR DESCRIPTION
Increase the max instances of inotify per user, from the default of 128 to 256.

Prevents `inotify cannot be used` errors when using `tail`.
