### PR TITLE
Raise max processes limit

### DIFF
--- a/files/etc/security/limits.conf
+++ b/files/etc/security/limits.conf
@@ -1,3 +1,3 @@
 * hard core 0
-* hard nproc 256
+* hard nproc 512
 * hard nofile 2048


### PR DESCRIPTION
The licensify unit tests require this to be set to 512 (or, at least, higher than 256) so the hard limit needs to be changed first.
