### PR TITLE
[96991670] Disable soft core dumps as per ITHC

### DIFF
--- a/files/etc/security/limits.conf
+++ b/files/etc/security/limits.conf
@@ -1,3 +1,3 @@
-* hard core 0
+* - core 0
 * hard nproc 256
 * hard nofile 2048


### PR DESCRIPTION
Ref:
http://manpages.ubuntu.com/manpages/trusty/man5/limits.conf.5.html

Adding the "-" instead of "hard" ensures "soft" core dumps are also
disabled at the same time as per the manpage.