### PR TITLE
Use lowercase 'n' in 'no'

### DIFF
--- a/files/etc/ssh/ssh_config
+++ b/files/etc/ssh/ssh_config
@@ -10,5 +10,5 @@ Host *
     Protocol 2
     SendEnv LANG LC_*
     StrictHostKeyChecking ask
-    UseRoaming No
+    UseRoaming no
     VisualHostKey yes


### PR DESCRIPTION
Most OpenSSH options take a value of `yes` or `no` (lowercase) according
to the man pages.

Having looked at the code with @rboulton, we don't think this will make
any difference, but it's good to be consistent:

https://github.com/openssh/openssh-portable/blob/V_6_6/readconf.c#L772

From http://linux.die.net/man/3/strcasecmp:
> The strcasecmp() function compares the two strings s1 and s2, ignoring
> the case of the characters.